### PR TITLE
from __future__ import print_function

### DIFF
--- a/auto_sort/asort.py
+++ b/auto_sort/asort.py
@@ -8,6 +8,7 @@
 # Version: 0.1
 # Description: A very simple python script that can sort items alphabetically.
 
+from __future__ import print_function
 import os
 import shutil
 

--- a/auto_sort/asort_zh.py
+++ b/auto_sort/asort_zh.py
@@ -8,6 +8,7 @@
 # Version: 0.1
 # Description: A very simple python script that can sort items alphabetically.
 
+from __future__ import print_function
 import os
 import shutil
 


### PR DESCRIPTION
Without this change, the `end` and `file` parameters in print() cause problems in Python 2.  This approach makes print(x, end=" ") valid syntax in both Python 2 and Python 3.